### PR TITLE
修正「𤒹」（「爗」）同「𠒇」（「兒」）讀音

### DIFF
--- a/list.tsv
+++ b/list.tsv
@@ -1829,7 +1829,7 @@ CH	UCODE	JP	INIT	FINL	TONE	DESC	DESC_JP
 𨩄	U+28A44	juk1	j	uk	1		
 𨥬	U+2896C	nou4	n	ou	4		
 𨥬	U+2896C	lou4	l	ou	4		
-𤒹	U+244B9	bat1	b	at	1		
+𤒹	U+244B9	jip6	j	ip	6		
 𤑳	U+24473	siu1	s	iu	1		
 𤏸	U+243F8	zyu3	z	yu	3		
 𡟯	U+217EF	jan1	j	an	1		
@@ -3166,7 +3166,7 @@ CH	UCODE	JP	INIT	FINL	TONE	DESC	DESC_JP
 𠍇	U+20347	caan3	c	aan	3		
 𠐟	U+2041F	liu4	l	iu	4		
 𤦤	U+249A4	ji4	j	i	4		
-𠒇	U+20487	maau6	m	aau	6		
+𠒇	U+20487	ji4	j	i	4		
 𣎴	U+233B4	dan2	d	an	2		
 𣎴	U+233B4	nip6	n	ip	6		
 𣎴	U+233B4	lip6	l	ip	6		


### PR DESCRIPTION
呢兩個字都係 HKSCS 單源 (single-source)，來源係人名。

「𠒇」係「兒」異體，以前喺香港都幾普遍，喺一啲幼兒園招牌仲見到。2007年香港小姐冠軍雷莊𠒇就話佢個名本身應該就係「兒」。

「𤒹」應該係「爗」嘅錯別字。MIRROR 副隊長江𤒹生嘅「𤒹」就係讀「業」，即係本身應該係「爗」。